### PR TITLE
openpriv/android-go-mobile update to 2021.03

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,8 +5,8 @@ FROM openjdk:8
 
 ENV SDK_URL="https://dl.google.com/android/repository/sdk-tools-linux-4333796.zip" \
     ANDROID_HOME="/usr/local/android-sdk" \
-    ANDROID_VERSION=28 \
-    ANDROID_BUILD_TOOLS_VERSION=28.0.1
+    ANDROID_VERSION=29 \
+    ANDROID_BUILD_TOOLS_VERSION=30.0.2
 
 ## Download Android SDK
 RUN mkdir "$ANDROID_HOME" .android \
@@ -33,7 +33,7 @@ RUN $ANDROID_HOME/tools/bin/sdkmanager "ndk-bundle"
 ## - docker run --rm debian:stretch grep '^hosts:' /etc/nsswitch.conf
 RUN echo 'hosts: files dns' > /etc/nsswitch.conf
 
-ENV GOLANG_VERSION 1.10.3
+ENV GOLANG_VERSION 1.16.2
 
 RUN set -eux; \
 	apt-get update; \
@@ -64,7 +64,7 @@ RUN set -eux; \
 	esac; \
 	\
 	wget -O go.tgz "https://golang.org/dl/go$GOLANG_VERSION.src.tar.gz"; \
-	echo '567b1cc66c9704d1c019c50bef946272e911ec6baf244310f87f4e678be155f2 *go.tgz' | sha256sum -c -; \
+	echo '37ca14287a23cb8ba2ac3f5c3dd8adbc1f7a54b9701a57824bf19a0b271f83ea *go.tgz' | sha256sum -c -; \
 	tar -C /usr/local -xzf go.tgz; \
 	rm go.tgz; \
 	\
@@ -88,5 +88,10 @@ ENV PATH $GOPATH/bin:$PATH
 RUN mkdir -p "$GOPATH/src" "$GOPATH/bin" "$GOPATH/pkg" && chmod -R 777 "$GOPATH"
 
 # install gomobile
-RUN go get golang.org/x/mobile/cmd/gomobile
-RUN gomobile init -ndk $ANDROID_HOME/ndk-bundle/
+RUN go install golang.org/x/mobile/cmd/gomobile@latest
+RUN go install golang.org/x/mobile/cmd/gobind@latest
+
+#RUN go get -u golang.org/x/mobile
+#RUN go get -u golang.org/x/mobile/bind
+
+# RUN gomobile init

--- a/Dockerfile
+++ b/Dockerfile
@@ -81,7 +81,7 @@ ENV PATH /usr/local/go/bin:$PATH
 RUN mkdir /gomobile
 # Set up GOPATH in /workspace
 ENV GOPATH /gomobile:/go
-ENV PATH $GOPATH/bin:$PATH
+ENV PATH /gomobile/bin:$PATH
 RUN mkdir -p "$GOPATH/src" "$GOPATH/bin" "$GOPATH/pkg" && chmod -R 777 "$GOPATH"
 
 # install gomobile

--- a/Dockerfile
+++ b/Dockerfile
@@ -78,12 +78,9 @@ RUN set -eux; \
 ENV PATH /usr/local/go/bin:$PATH
 
 # Setup /workspace
-RUN mkdir /workspace
-RUN mkdir /go
-# link $GOPATH to persistent /go
-RUN ln -sf /go /workspace/go
+RUN mkdir /gomobile
 # Set up GOPATH in /workspace
-ENV GOPATH /workspace/go
+ENV GOPATH /gomobile:/go
 ENV PATH $GOPATH/bin:$PATH
 RUN mkdir -p "$GOPATH/src" "$GOPATH/bin" "$GOPATH/pkg" && chmod -R 777 "$GOPATH"
 
@@ -91,7 +88,5 @@ RUN mkdir -p "$GOPATH/src" "$GOPATH/bin" "$GOPATH/pkg" && chmod -R 777 "$GOPATH"
 RUN go install golang.org/x/mobile/cmd/gomobile@latest
 RUN go install golang.org/x/mobile/cmd/gobind@latest
 
-#RUN go get -u golang.org/x/mobile
-#RUN go get -u golang.org/x/mobile/bind
-
 # RUN gomobile init
+

--- a/Dockerfile
+++ b/Dockerfile
@@ -23,7 +23,9 @@ RUN $ANDROID_HOME/tools/bin/sdkmanager "build-tools;${ANDROID_BUILD_TOOLS_VERSIO
     "platform-tools"
 
 # Install NDK
-RUN $ANDROID_HOME/tools/bin/sdkmanager "ndk-bundle"
+ENV NDK_VER="17.2.4988734" 
+RUN $ANDROID_HOME/tools/bin/sdkmanager "ndk;$NDK_VER"
+RUN ln -sf $ANDROID_HOME/ndk/$NDK_VER $ANDROID_HOME/ndk-bundle
 
 # Go section of this Dockerfile from Docker golang: https://github.com/docker-library/golang/blob/master/1.10/alpine3.8/Dockerfile
 # Adapted from alpine apk to debian apt
@@ -88,5 +90,15 @@ ENV PATH $GOPATH/bin:$PATH
 RUN mkdir -p "$GOPATH/src" "$GOPATH/bin" "$GOPATH/pkg" && chmod -R 777 "$GOPATH"
 
 # install gomobile
-RUN go get golang.org/x/mobile/cmd/gomobile
+RUN cd /workspace/go/src; \ 
+	mkdir -p golang.org/x; \
+	cd golang.org/x; \
+	git clone https://github.com/golang/mobile.git; \
+	cd mobile; \
+	git checkout 507816974b79c76a5fe70f9580265cd57dc78bbe; 
+	
+RUN go install golang.org/x/mobile/cmd/gomobile
+
+#RUN go get golang.org/x/mobile/cmd/gomobile@v0.0.0-20200629153529-33b80540585f
+
 RUN gomobile init -ndk $ANDROID_HOME/ndk-bundle/

--- a/Dockerfile
+++ b/Dockerfile
@@ -84,13 +84,15 @@ ENV GOMOBILEPATH /gomobile
 # Setup /workspace
 RUN mkdir $GOMOBILEPATH
 # Set up GOPATH in /workspace
-ENV GOPATH $GOMOBILEPATH:/go
+ENV GOPATH $GOMOBILEPATH
 ENV PATH $GOMOBILEPATH/bin:$PATH
 RUN mkdir -p "$GOMOBILEPATH/src" "$GOMOBILEPATH/bin" "$GOMOBILEPATH/pkg" && chmod -R 777 "$GOMOBILEPATH"
 
 # install gomobile
 RUN go get golang.org/x/mobile/cmd/gomobile
 RUN go get golang.org/x/mobile/cmd/gobind
+RUN go get golang.org/x/mobile/bind
 
+RUN gomobile clean
 # RUN gomobile init
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -94,5 +94,3 @@ RUN go get golang.org/x/mobile/cmd/gobind
 RUN go get golang.org/x/mobile/bind
 
 RUN gomobile clean
-# RUN gomobile init
-

--- a/Dockerfile
+++ b/Dockerfile
@@ -35,7 +35,8 @@ ENV ANDROID_NDK_ROOT $ANDROID_HOME/ndk-bundle
 ## - docker run --rm debian:stretch grep '^hosts:' /etc/nsswitch.conf
 RUN echo 'hosts: files dns' > /etc/nsswitch.conf
 
-ENV GOLANG_VERSION 1.16.2
+ENV GOLANG_VERSION 1.15.10
+ENV GOLANG_SHA256 c1dbca6e0910b41d61a95bf9878f6d6e93d15d884c226b91d9d4b1113c10dd65
 
 RUN set -eux; \
 	apt-get update; \
@@ -66,7 +67,7 @@ RUN set -eux; \
 	esac; \
 	\
 	wget -O go.tgz "https://golang.org/dl/go$GOLANG_VERSION.src.tar.gz"; \
-	echo '37ca14287a23cb8ba2ac3f5c3dd8adbc1f7a54b9701a57824bf19a0b271f83ea *go.tgz' | sha256sum -c -; \
+	echo "$GOLANG_SHA256 *go.tgz" | sha256sum -c -; \
 	tar -C /usr/local -xzf go.tgz; \
 	rm go.tgz; \
 	\
@@ -88,8 +89,8 @@ ENV PATH $GOMOBILEPATH/bin:$PATH
 RUN mkdir -p "$GOMOBILEPATH/src" "$GOMOBILEPATH/bin" "$GOMOBILEPATH/pkg" && chmod -R 777 "$GOMOBILEPATH"
 
 # install gomobile
-RUN go install golang.org/x/mobile/cmd/gomobile@latest
-RUN go install golang.org/x/mobile/cmd/gobind@latest
+RUN go get golang.org/x/mobile/cmd/gomobile
+RUN go get golang.org/x/mobile/cmd/gobind
 
 # RUN gomobile init
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,6 +5,7 @@ FROM openjdk:8
 
 ENV SDK_URL="https://dl.google.com/android/repository/sdk-tools-linux-4333796.zip" \
     ANDROID_HOME="/usr/local/android-sdk" \
+    ANDROID_SDK=$ANDROID_HOME \
     ANDROID_VERSION=29 \
     ANDROID_BUILD_TOOLS_VERSION=30.0.2
 
@@ -24,6 +25,7 @@ RUN $ANDROID_HOME/tools/bin/sdkmanager "build-tools;${ANDROID_BUILD_TOOLS_VERSIO
 
 # Install NDK
 RUN $ANDROID_HOME/tools/bin/sdkmanager "ndk-bundle"
+ENV ANDROID_NDK_ROOT $ANDROID_HOME/ndk-bundle
 
 # Go section of this Dockerfile from Docker golang: https://github.com/docker-library/golang/blob/master/1.10/alpine3.8/Dockerfile
 # Adapted from alpine apk to debian apt
@@ -77,12 +79,13 @@ RUN set -eux; \
 # persist new go in PATH
 ENV PATH /usr/local/go/bin:$PATH
 
+ENV GOMOBILEPATH /gomobile
 # Setup /workspace
-RUN mkdir /gomobile
+RUN mkdir $GOMOBILEPATH
 # Set up GOPATH in /workspace
-ENV GOPATH /gomobile:/go
-ENV PATH /gomobile/bin:$PATH
-RUN mkdir -p "$GOPATH/src" "$GOPATH/bin" "$GOPATH/pkg" && chmod -R 777 "$GOPATH"
+ENV GOPATH $GOMOBILEPATH:/go
+ENV PATH $GOMOBILEPATH/bin:$PATH
+RUN mkdir -p "$GOMOBILEPATH/src" "$GOMOBILEPATH/bin" "$GOMOBILEPATH/pkg" && chmod -R 777 "$GOMOBILEPATH"
 
 # install gomobile
 RUN go install golang.org/x/mobile/cmd/gomobile@latest

--- a/README.md
+++ b/README.md
@@ -2,6 +2,19 @@
 
 This image was built for use with Drone CI but can be used with any docker setup you want.
 
+Versions are:
+
+- 2021.03
+	- Go 1.15.10
+	- Android API 29
+- 2018.07
+	- Go 1.10.3
+	- Android API 28
+
+## Install and Use
+
+### Version 2018.07
+
 This image includes:
 
 - Android SDK, NDK, tools, and API version 28 at `/usr/local/android-sdk`

--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ Versions are:
 - 2018.07
 	- Go 1.10.3
 	- Android API 28
+	- NDK 17.2.4988734
 
 ## Install and Use
 

--- a/README.md
+++ b/README.md
@@ -7,9 +7,11 @@ Versions are:
 - 2021.03
 	- Go 1.15.10
 	- Android API 29
+	- NDK 21.0.6113669
 - 2018.07
 	- Go 1.10.3
 	- Android API 28
+	- NDK 17.2.4988734
 
 ## Install and Use
 
@@ -31,3 +33,20 @@ This container has its own GOPATH with only gomobile in it, so to use, you'll ne
 	- gomobile init
 	- make
 
+### Version 2018.07
+
+This image includes:
+
+- Android SDK, NDK, tools, and API version 28 at `/usr/local/android-sdk`
+- Go lang 1.10.3 at `/usr/local/go`
+- $GOPATH set to `/workspace/go`
+- A go directory with an initialized gomobile installed at `/go`
+
+This image comes with gomobile checkedout and preinitialized (time and space consuming). In order to install this predone work from the image into your Drone CI workspace (a docker volume mounted to `/workspace`), you will want your first pipeline step to be:
+
+    go-link:
+      image: openpriv/android-go-mobile
+      commands:
+        - cp -as /go /workspace/go
+
+`cp -as` recreates the directory structure from /go in /workspace/go but for each file, it just creates a symlink. This is the quickest and most efficent way to mirror the work supplied with the image into your workspace.

--- a/README.md
+++ b/README.md
@@ -13,20 +13,21 @@ Versions are:
 
 ## Install and Use
 
-### Version 2018.07
+### Version 2021.03
 
 This image includes:
 
-- Android SDK, NDK, tools, and API version 28 at `/usr/local/android-sdk`
+- Android SDK, NDK, tools, and API version 29 and Buildtools 30.0.2 at `/usr/local/android-sdk`
 - Go lang 1.10.3 at `/usr/local/go`
-- $GOPATH set to `/workspace/go`
-- A go directory with an initialized gomobile installed at `/go`
+- $GOPATH set to `/gomobile`
+	- GOPATH includes gomobile cmd tools and source
 
-This image comes with gomobile checkedout and preinitialized (time and space consuming). In order to install this predone work from the image into your Drone CI workspace (a docker volume mounted to `/workspace`), you will want your first pipeline step to be:
+This container has its own GOPATH with only gomobile in it, so to use, you'll need to re-get your go dependancies and then run `gomobile init`.  The following example shows a Drone CI step using this image
 
-    go-link:
-      image: openpriv/android-go-mobile
+    gomobile-build:
+      image: openpriv/android-go-mobile:2021.03
       commands:
-        - cp -as /go /workspace/go
+        - go mod download
+	- gomobile init
+	- make
 
-`cp -as` recreates the directory structure from /go in /workspace/go but for each file, it just creates a symlink. This is the quickest and most efficent way to mirror the work supplied with the image into your workspace.

--- a/README.md
+++ b/README.md
@@ -30,8 +30,8 @@ This container has its own GOPATH with only gomobile in it, so to use, you'll ne
       image: openpriv/android-go-mobile:2021.03
       commands:
         - go mod download
-	- gomobile init
-	- make
+        - gomobile init
+        - make
 
 ### Version 2018.07
 

--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@ Versions are:
 - 2021.03
 	- Go 1.15.10
 	- Android API 29
+	- NDK 21.0.6113669
 - 2018.07
 	- Go 1.10.3
 	- Android API 28

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ Versions are:
 This image includes:
 
 - Android SDK, NDK, tools, and API version 29 and Buildtools 30.0.2 at `/usr/local/android-sdk`
-- Go lang 1.10.3 at `/usr/local/go`
+- Go lang 1.15.10 at `/usr/local/go`
 - $GOPATH set to `/gomobile`
 	- GOPATH includes gomobile cmd tools and source
 


### PR DESCRIPTION
Just a heads up, I've updated the Dockerfile to
- use go1.15
- Updated Android and NDK
- version more things so it can still be built later (this includes in the now old version 2018.07 branch)

Feel free to ignore or take what you want :)